### PR TITLE
[PATCH] fix - remove Error on calling init multiple times, fixes #22

### DIFF
--- a/src/r7insight.js
+++ b/src/r7insight.js
@@ -356,7 +356,7 @@
         if (typeof options.name !== "string")
             throw new Error("Name not present.");
         else if (loggers.hasOwnProperty(options.name))
-            throw new Error("A logger with that name already exists!");
+            return true; // logger already exists
         loggers[options.name] = new Logger(options);
 
         return true;

--- a/test/r7insightSpec.js
+++ b/test/r7insightSpec.js
@@ -522,6 +522,56 @@ describe('full custom endpoint', function () {
     afterEach(destroy);
 });
 
+
+describe('Multiple initialisations', function () {
+    beforeEach(mockXMLHttpRequests);
+    beforeEach(addGetJson);
+    beforeEach(function () {
+        R7Insight.init({
+            token: TOKEN,
+            region: 'eu'
+        });
+    });
+
+    it('should allow calling init on already set up logger', function () {
+        R7Insight.init({
+            token: TOKEN,
+            region: 'eu'
+        });
+        R7Insight.log('some message');
+        var lastReq = this.requestList[0];
+        expect(this.getXhrJson(0).event).toBe('some message');
+    });
+
+    afterEach(restoreXMLHttpRequests);
+    afterEach(destroy);
+});
+
+describe('Multiple initialisations', function () {
+    beforeEach(mockXMLHttpRequests);
+    beforeEach(addGetJson);
+    beforeEach(function () {
+        R7Insight.init({
+            name: 'test',
+            token: TOKEN,
+            region: 'eu'
+        });
+    });
+
+    it('should allow calling init on already set up logger with name', function () {
+        R7Insight.init({
+            name: 'test',
+            token: TOKEN,
+            region: 'eu'
+        });
+        R7Insight.log('some message');
+        expect(this.getXhrJson(0).event).toBe('some message');
+    });
+
+    afterEach(restoreXMLHttpRequests);
+    afterEach(destroy);
+});
+
 describe('print option', function () {
     beforeEach(mockXMLHttpRequests);
     beforeEach(function () {


### PR DESCRIPTION
Description
---
* Raised by @Haraldson in https://github.com/rapid7/r7insight_js/issues/22
* Removing the error thrown when init or createLogStream is called multiple times. Now will no-op.
* Added tests that fail on previous version.
* Proposed semver release of PATCH.